### PR TITLE
Use setup-micromamba for cfn-lint action

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,11 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5
+
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: 3.13
-      - run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          environment-file: environment.yml
+
       - run: |
           cfn-lint --info --ignore-checks W3002 --template app/cloudformation.yml

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,5 +24,6 @@ jobs:
         with:
           environment-file: environment.yml
 
-      - run: |
+      - shell: bash -l {0}
+        run: |
           cfn-lint --info --ignore-checks W3002 --template app/cloudformation.yml


### PR DESCRIPTION
Slightly decouples the action from the underlying packages/python version.