### PR TITLE
break tag and release into separate actions to resolve invalid GITHUB_REF error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   create-release:
-    needs: create-tag
     uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.17.1
     with:
       release_prefix: Ingest Adapter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,11 @@
-name: Tag version and create release
+name: Create release and sync to default branch
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - v*
 
 jobs:
-  create-tag:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.17.1
-    secrets:
-      USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
-
   create-release:
     needs: create-tag
     uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.17.1

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,12 @@
+name: Tag release version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-tag:
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.17.1
+    secrets:
+      USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}


### PR DESCRIPTION
`reusable-bump-version.yml` expects the triggering `GITHUB_REF` to be a `vX.Y.Z`  tag, not a `main` branch.